### PR TITLE
Reconnect + Progress

### DIFF
--- a/Glider.xcodeproj/project.pbxproj
+++ b/Glider.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A905E1DF26824ADA0051C558 /* Readme.md in Resources */ = {isa = PBXBuildFile; fileRef = A905E1DE26824AD90051C558 /* Readme.md */; };
+		A919BA6A26791585000C9291 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A919BA6926791585000C9291 /* AppState.swift */; };
 		A947FE432654383A007A5E5A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A947FE422654383A007A5E5A /* Preview Assets.xcassets */; };
 		A947FE8226543894007A5E5A /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = A947FE4C26543893007A5E5A /* ButtonStyles.swift */; };
 		A947FE8326543894007A5E5A /* DefaultBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = A947FE4E26543893007A5E5A /* DefaultBackground.swift */; };
@@ -22,7 +24,7 @@
 		A947FE8D26543894007A5E5A /* StartupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A947FE5A26543893007A5E5A /* StartupViewModel.swift */; };
 		A947FE8E26543894007A5E5A /* FileTransferViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A947FE5B26543893007A5E5A /* FileTransferViewModel.swift */; };
 		A947FE8F26543894007A5E5A /* AutoConnectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A947FE5C26543893007A5E5A /* AutoConnectViewModel.swift */; };
-		A947FE9026543894007A5E5A /* AdafruitBoard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A947FE5F26543893007A5E5A /* AdafruitBoard.swift */; };
+		A947FE9026543894007A5E5A /* FileTransferClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A947FE5F26543893007A5E5A /* FileTransferClient.swift */; };
 		A947FE9226543894007A5E5A /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A947FE6126543893007A5E5A /* Settings.swift */; };
 		A947FE9326543894007A5E5A /* PeripheralList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A947FE6326543893007A5E5A /* PeripheralList.swift */; };
 		A947FE9426543894007A5E5A /* PeripheralAutoConnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = A947FE6426543893007A5E5A /* PeripheralAutoConnect.swift */; };
@@ -49,9 +51,12 @@
 		A9F22528265B9DE800D3B2C6 /* FileChooserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F22527265B9DE800D3B2C6 /* FileChooserViewModel.swift */; };
 		A9F2252A265BA80F00D3B2C6 /* FileTransferUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F22529265BA80F00D3B2C6 /* FileTransferUtils.swift */; };
 		A9F2252C265C85ED00D3B2C6 /* TextFieldAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F2252B265C85ED00D3B2C6 /* TextFieldAlert.swift */; };
+		A9FEDC582680AC1200E409FA /* BleAutoReconnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FEDC572680AC1200E409FA /* BleAutoReconnect.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		A905E1DE26824AD90051C558 /* Readme.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = Readme.md; sourceTree = SOURCE_ROOT; };
+		A919BA6926791585000C9291 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		A947FE3826543839007A5E5A /* Glider.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Glider.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A947FE422654383A007A5E5A /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		A947FE442654383A007A5E5A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -69,7 +74,7 @@
 		A947FE5A26543893007A5E5A /* StartupViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartupViewModel.swift; sourceTree = "<group>"; };
 		A947FE5B26543893007A5E5A /* FileTransferViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileTransferViewModel.swift; sourceTree = "<group>"; };
 		A947FE5C26543893007A5E5A /* AutoConnectViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoConnectViewModel.swift; sourceTree = "<group>"; };
-		A947FE5F26543893007A5E5A /* AdafruitBoard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdafruitBoard.swift; sourceTree = "<group>"; };
+		A947FE5F26543893007A5E5A /* FileTransferClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileTransferClient.swift; sourceTree = "<group>"; };
 		A947FE6126543893007A5E5A /* Settings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		A947FE6326543893007A5E5A /* PeripheralList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeripheralList.swift; sourceTree = "<group>"; };
 		A947FE6426543893007A5E5A /* PeripheralAutoConnect.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeripheralAutoConnect.swift; sourceTree = "<group>"; };
@@ -96,6 +101,7 @@
 		A9F22527265B9DE800D3B2C6 /* FileChooserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileChooserViewModel.swift; sourceTree = "<group>"; };
 		A9F22529265BA80F00D3B2C6 /* FileTransferUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTransferUtils.swift; sourceTree = "<group>"; };
 		A9F2252B265C85ED00D3B2C6 /* TextFieldAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldAlert.swift; sourceTree = "<group>"; };
+		A9FEDC572680AC1200E409FA /* BleAutoReconnect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BleAutoReconnect.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -128,6 +134,7 @@
 		A947FE3A26543839007A5E5A /* Glider */ = {
 			isa = PBXGroup;
 			children = (
+				A905E1DE26824AD90051C558 /* Readme.md */,
 				A947FE7926543893007A5E5A /* App */,
 				A947FE4A26543893007A5E5A /* Views */,
 				A947FE5726543893007A5E5A /* ViewModels */,
@@ -211,6 +218,7 @@
 				A947FE6126543893007A5E5A /* Settings.swift */,
 				A947FE5E26543893007A5E5A /* AdafruitBoard */,
 				A947FE6226543893007A5E5A /* Scanner */,
+				A919BA6926791585000C9291 /* AppState.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -218,7 +226,7 @@
 		A947FE5E26543893007A5E5A /* AdafruitBoard */ = {
 			isa = PBXGroup;
 			children = (
-				A947FE5F26543893007A5E5A /* AdafruitBoard.swift */,
+				A947FE5F26543893007A5E5A /* FileTransferClient.swift */,
 			);
 			path = AdafruitBoard;
 			sourceTree = "<group>";
@@ -275,6 +283,7 @@
 				A947FE6E26543893007A5E5A /* BlePeripheral.swift */,
 				A947FE6F26543893007A5E5A /* BleManager.swift */,
 				A947FE7026543893007A5E5A /* BlePeripheral+Battery.swift */,
+				A9FEDC572680AC1200E409FA /* BleAutoReconnect.swift */,
 			);
 			path = BleCentralMode;
 			sourceTree = "<group>";
@@ -370,6 +379,7 @@
 			files = (
 				A947FE432654383A007A5E5A /* Preview Assets.xcassets in Resources */,
 				A947FEAA2654392F007A5E5A /* Assets.xcassets in Resources */,
+				A905E1DF26824ADA0051C558 /* Readme.md in Resources */,
 				A947FE9526543894007A5E5A /* DefaultPreferences.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -389,9 +399,10 @@
 				A947FE8226543894007A5E5A /* ButtonStyles.swift in Sources */,
 				A947FE9226543894007A5E5A /* Settings.swift in Sources */,
 				A947FE8A26543894007A5E5A /* MainView.swift in Sources */,
-				A947FE9026543894007A5E5A /* AdafruitBoard.swift in Sources */,
+				A947FE9026543894007A5E5A /* FileTransferClient.swift in Sources */,
 				A947FE9426543894007A5E5A /* PeripheralAutoConnect.swift in Sources */,
 				A947FE8B26543894007A5E5A /* TodoView.swift in Sources */,
+				A919BA6A26791585000C9291 /* AppState.swift in Sources */,
 				A947FE9726543894007A5E5A /* BlePeripheral+FileTransfer.swift in Sources */,
 				A947FE9326543894007A5E5A /* PeripheralList.swift in Sources */,
 				A947FE8926543894007A5E5A /* FileTransferView.swift in Sources */,
@@ -415,6 +426,7 @@
 				A947FE8826543894007A5E5A /* RootView.swift in Sources */,
 				A947FE8E26543894007A5E5A /* FileTransferViewModel.swift in Sources */,
 				A947FE8C26543894007A5E5A /* RootViewModel.swift in Sources */,
+				A9FEDC582680AC1200E409FA /* BleAutoReconnect.swift in Sources */,
 				A947FE9F26543894007A5E5A /* CommandQueue.swift in Sources */,
 				A947FE8726543894007A5E5A /* HideKeyboard.swift in Sources */,
 				A947FE8326543894007A5E5A /* DefaultBackground.swift in Sources */,
@@ -548,7 +560,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_ASSET_PATHS = "\"Glider/Preview Content\"";
 				DEVELOPMENT_TEAM = 2X94RM7457;
 				ENABLE_PREVIEWS = YES;
@@ -558,7 +570,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2;
+				MARKETING_VERSION = 0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adafruit.Glider.test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -572,7 +584,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_ASSET_PATHS = "\"Glider/Preview Content\"";
 				DEVELOPMENT_TEAM = 2X94RM7457;
 				ENABLE_PREVIEWS = YES;
@@ -582,7 +594,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2;
+				MARKETING_VERSION = 0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adafruit.Glider.test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/Glider.xcodeproj/xcshareddata/xcschemes/Glider.xcscheme
+++ b/Glider.xcodeproj/xcshareddata/xcschemes/Glider.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A947FE3726543839007A5E5A"
+               BuildableName = "Glider.app"
+               BlueprintName = "Glider"
+               ReferencedContainer = "container:Glider.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A947FE3726543839007A5E5A"
+            BuildableName = "Glider.app"
+            BlueprintName = "Glider"
+            ReferencedContainer = "container:Glider.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A947FE3726543839007A5E5A"
+            BuildableName = "Glider.app"
+            BlueprintName = "Glider"
+            ReferencedContainer = "container:Glider.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Glider/AdafruitKit/Ble/BleCentralMode/BleAutoReconnect.swift
+++ b/Glider/AdafruitKit/Ble/BleCentralMode/BleAutoReconnect.swift
@@ -1,0 +1,149 @@
+//
+//  BleAutoReconnect.swift
+//  Glider
+//
+//  Created by Antonio García on 21/6/21.
+//
+
+import Foundation
+import CoreBluetooth
+
+class BleAutoReconnect {
+    // Params
+    private var servicesToReconnect: [CBUUID]
+    private var reconnectHandler: ((_ peripheral: BlePeripheral, _ completion: @escaping (Result<Void, Error>) -> Void) -> ())?
+    private let reconnectTimeout: TimeInterval
+
+    private var isReconnecting = false
+    var isDisconnectionMonitoringForAutoReconnectEnabled = false
+    
+    init(servicesToReconnect: [CBUUID], reconnectTimeout: TimeInterval = 2, reconnectHandler: @escaping ( BlePeripheral, @escaping (Result<Void, Error>) -> Void) -> ()) {
+        DLog("Init autoReconnect to known peripherals")
+        self.servicesToReconnect = servicesToReconnect
+        self.reconnectTimeout = reconnectTimeout
+        self.reconnectHandler = reconnectHandler
+        
+        registerConnectionNotifications(enabled: true)
+    }
+    
+    deinit {
+        // Unregister notifications
+        registerConnectionNotifications(enabled: false)
+    }
+    
+    /// Returns if is trying to reconnect, or false if it is quickly decided that there is not possible
+    @discardableResult
+    func reconnect() -> Bool {
+        if let identifier = Settings.autoconnectPeripheralUUID {
+            return self.reconnecToPeripheral(withIdentifier: identifier)
+        } else {
+            DLog("Reconnect finished")
+            NotificationCenter.default.post(name: .didFailToReconnectToKnownPeripheral, object: nil)
+            return false
+        }
+    }
+    
+    // MARK: - Reconnect previously connnected Ble Peripheral
+    private func reconnecToPeripheral(withIdentifier identifier: UUID) -> Bool {
+        DLog("Reconnecting...")
+        isReconnecting = true
+        
+        // Reconnect
+        let isTryingToReconnect = BleManager.shared.reconnecToPeripherals(peripheralUUIDs: [identifier], withServices: servicesToReconnect, timeout: reconnectTimeout)
+
+        if !isTryingToReconnect {
+            DLog("isTryingToReconnect false. Go to next")
+            connected(peripheral: nil)
+        }
+        
+        return isTryingToReconnect
+    }
+
+    private func didConnectToPeripheral(_ notification: Notification) {
+        guard isReconnecting else {
+            if let identifier = notification.userInfo?[BleManager.NotificationUserInfoKey.uuid.rawValue] as? UUID {
+                DLog("AutoReconnect detected connection. Save identifier.");
+                Settings.autoconnectPeripheralUUID = identifier
+            }
+            return }
+        
+        guard let peripheral = BleManager.shared.peripheral(from: notification) else {
+            DLog("Connected to an unknown peripheral")
+            connected(peripheral: nil)
+            return
+        }
+
+        connected(peripheral: peripheral)
+    }
+
+    private func didDisconnectFromPeripheral() {
+        if isReconnecting {
+            // Autoconnect failed
+            connected(peripheral: nil)
+        }
+        else if isDisconnectionMonitoringForAutoReconnectEnabled {
+            DLog("AutoReconnect: Disconnection detected. Trying to auto reconnect")
+            reconnect()
+        }
+    }
+
+    private func connected(peripheral: BlePeripheral?) {
+        isReconnecting = false      // Finished reconnection process
+
+        //
+        if let peripheral = peripheral {
+            // Show restoring connection label
+            NotificationCenter.default.post(name: .willReconnectToKnownPeripheral, object: nil, userInfo: [BleManager.NotificationUserInfoKey.uuid.rawValue: peripheral.identifier])
+
+            reconnectHandler?(peripheral) { result in
+                switch result {
+                case .success:
+                    DLog("Reconnected to peripheral successfully")
+                    
+                    // Check if filetransfer was setup
+                    guard let fileTransferClient = AppState.shared.fileTransferClient, fileTransferClient.isFileTransferEnabled else {
+                        DLog("setupPeripheral fileTransfer not enabled")
+                        NotificationCenter.default.post(name: .didFailToReconnectToKnownPeripheral, object: nil, userInfo: [BleManager.NotificationUserInfoKey.uuid.rawValue: peripheral.identifier])
+                        BleManager.shared.disconnect(from: peripheral)
+                        return
+                    }
+                    
+                    NotificationCenter.default.post(name: .didReconnectToKnownPeripheral, object: nil, userInfo: [BleManager.NotificationUserInfoKey.uuid.rawValue: peripheral.identifier])
+
+                case .failure(let error):
+                    DLog("Failed to setup peripheral: \(error.localizedDescription)")
+                    BleManager.shared.disconnect(from: peripheral)
+
+                    Settings.clearAutoconnectPeripheral()
+                    NotificationCenter.default.post(name: .didFailToReconnectToKnownPeripheral, object: nil, userInfo: [BleManager.NotificationUserInfoKey.uuid.rawValue: peripheral.identifier])
+                }
+            }
+
+        } else {
+            Settings.clearAutoconnectPeripheral()
+            NotificationCenter.default.post(name: .didFailToReconnectToKnownPeripheral, object: nil)
+        }
+    }
+    
+    // MARK: - Notifications
+    private var didConnectToPeripheralObserver: NSObjectProtocol?
+    private var didDisconnectFromPeripheralObserver: NSObjectProtocol?
+
+    private func registerConnectionNotifications(enabled: Bool) {
+        if enabled {
+            didConnectToPeripheralObserver = NotificationCenter.default.addObserver(forName: .didConnectToPeripheral, object: nil, queue: .main, using: { [weak self] notification in self?.didConnectToPeripheral(notification)})
+            didDisconnectFromPeripheralObserver = NotificationCenter.default.addObserver(forName: .didDisconnectFromPeripheral, object: nil, queue: .main, using: { [weak self] _ in self?.didDisconnectFromPeripheral()})
+        } else {
+            if let didConnectToPeripheralObserver = didConnectToPeripheralObserver {NotificationCenter.default.removeObserver(didConnectToPeripheralObserver)}
+            if let didDisconnectFromPeripheralObserver = didDisconnectFromPeripheralObserver {NotificationCenter.default.removeObserver(didDisconnectFromPeripheralObserver)}
+        }
+    }
+}
+
+// MARK: - Custom Notifications
+extension Notification.Name {
+    private static let kPrefix = Bundle.main.bundleIdentifier!
+    static let willReconnectToKnownPeripheral = Notification.Name(kPrefix+".willReconnectToKnownPeripheral")
+    static let didReconnectToKnownPeripheral = Notification.Name(kPrefix+".didReconnectToKnownPeripheral")
+    static let didFailToReconnectToKnownPeripheral = Notification.Name(kPrefix+".didFailToReconnectToKnownPeripheral")
+}

--- a/Glider/AdafruitKit/Ble/BleCentralMode/BleManager.swift
+++ b/Glider/AdafruitKit/Ble/BleCentralMode/BleManager.swift
@@ -256,31 +256,26 @@ class BleManager: NSObject {
         }
     }
     
-    func reconnecToPeripherals(peripheralsData: [(identifier: UUID, advertisementData: [String: Any])], withServices services: [CBUUID], timeout: Double? = nil) -> Bool {
+    func reconnecToPeripherals(peripheralUUIDs identifiers: [UUID], withServices services: [CBUUID], timeout: Double? = nil) -> Bool {
         var reconnecting = false
         
-        let identifiers = peripheralsData.map({$0.identifier})
         let knownPeripherals = centralManager?.retrievePeripherals(withIdentifiers: identifiers)
         if let peripherals = knownPeripherals?.filter({identifiers.contains($0.identifier)}), !peripherals.isEmpty {
             for peripheral in peripherals {
-                if let peripheralData = peripheralsData.first(where: {$0.identifier == peripheral.identifier}) {
-                    discovered(peripheral: peripheral, advertisementData: peripheralData.advertisementData)
-                    if let blePeripheral = peripheralsFound[peripheral.identifier] {
-                        connect(to: blePeripheral, timeout: timeout)
-                        reconnecting = true
-                    }
+                discovered(peripheral: peripheral, advertisementData: nil)
+                if let blePeripheral = peripheralsFound[peripheral.identifier] {
+                    connect(to: blePeripheral, timeout: timeout)
+                    reconnecting = true
                 }
             }
         } else {
             let connectedPeripherals = centralManager?.retrieveConnectedPeripherals(withServices: services)
             if let peripherals = connectedPeripherals?.filter({identifiers.contains($0.identifier)}), !peripherals.isEmpty {
                 for peripheral in peripherals {
-                    if let peripheralData = peripheralsData.first(where: {$0.identifier == peripheral.identifier}) {
-                        discovered(peripheral: peripheral, advertisementData: peripheralData.advertisementData )
-                        if let blePeripheral = peripheralsFound[peripheral.identifier] {
-                            connect(to: blePeripheral, timeout: timeout)
-                            reconnecting = true
-                        }
+                    discovered(peripheral: peripheral, advertisementData: nil )
+                    if let blePeripheral = peripheralsFound[peripheral.identifier] {
+                        connect(to: blePeripheral, timeout: timeout)
+                        reconnecting = true
                     }
                 }
             }
@@ -312,6 +307,7 @@ class BleManager: NSObject {
         }
     }
 
+    
     // MARK: - Notifications
     func peripheral(from notification: Notification) -> BlePeripheral? {
         guard let uuid = notification.userInfo?[NotificationUserInfoKey.uuid.rawValue] as? UUID else { return nil }

--- a/Glider/App/AppDelegate.swift
+++ b/Glider/App/AppDelegate.swift
@@ -28,5 +28,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         UITableView.appearance().backgroundColor = UIColor.clear
         UITableView.appearance().separatorStyle = .none
         UITableViewCell.appearance().backgroundColor = .clear
+        
+        // Alerts
+        UIView.appearance(whenContainedInInstancesOf: [UIAlertController.self]).tintColor = .blue
     }
 }

--- a/Glider/Models/AppState.swift
+++ b/Glider/Models/AppState.swift
@@ -1,0 +1,41 @@
+//
+//  AppState.swift
+//  Glider
+//
+//  Created by Antonio García on 15/6/21.
+//
+
+import Foundation
+
+class AppState: ObservableObject {
+    // Singleton
+    static let shared = AppState()
+    
+    // Published
+    @Published var fileTransferClient: FileTransferClient? = nil
+    
+    // Data
+    private var autoReconnect: BleAutoReconnect?
+
+    public func startAutoReconnect() {
+        autoReconnect = BleAutoReconnect(servicesToReconnect: [BlePeripheral.kFileTransferServiceUUID], reconnectHandler: { [unowned self] (peripheral: BlePeripheral, completion: @escaping (Result<Void, Error>) -> Void) in
+            
+            self.fileTransferClient = FileTransferClient(connectedBlePeripheral: peripheral, services: [.filetransfer], completion: completion)
+        })
+    }
+    
+    public func stopAutoReconnect() {
+        autoReconnect = nil
+    }
+    
+    /// Returns if is trying to reconnect, or false if it is quickly decided that there is not possible
+    @discardableResult
+    public func forceReconnect() -> Bool {
+        guard let autoReconnect = autoReconnect else { DLog("Error: reconnect called without calling startAutoReconnect"); return false }
+        return autoReconnect.reconnect()
+    }
+    
+    public func clearAutoconnectPeripheral() {
+        Settings.clearAutoconnectPeripheral()
+    }
+}

--- a/Glider/Models/Scanner/PeripheralAutoConnect.swift
+++ b/Glider/Models/Scanner/PeripheralAutoConnect.swift
@@ -20,7 +20,7 @@ import Foundation
 class PeripheralAutoConnect {
     // Config
     private static let kMinScanningTimeToAutoconnect: TimeInterval = 1.5 // 5
-    private static let kMinRssiToAutoConnect = -56      // in dBM
+    private static let kMinRssiToAutoConnect = -80      // in dBM
     private static let kMinTimeDetectingPeripheralForAutoconnect: TimeInterval = 1
 
     // Data

--- a/Glider/Models/Settings.swift
+++ b/Glider/Models/Settings.swift
@@ -11,26 +11,40 @@ import Foundation
 class Settings {
     // Constants
     private static let autoconnectPeripheralIdentifierKey = "autoconnectPeripheralIdentifier"
-    private static let autoconnectPeripheralAdvertisementDataKey = "autoconnectPeripheralAdvertisementData"
+    //private static let autoconnectPeripheralAdvertisementDataKey = "autoconnectPeripheralAdvertisementData"
 
     // MARK: - AutoConnect
+    static var autoconnectPeripheralUUID: UUID? {
+        get {
+            guard let uuidString = UserDefaults.standard.string(forKey: Self.autoconnectPeripheralIdentifierKey), let uuid = UUID(uuidString: uuidString) else { return nil}
+            return uuid
+        }
+        
+        set {
+            let uuidString = newValue?.uuidString
+            DLog("Set autoconnect peripheral: \(uuidString ?? "<nil>")")
+            UserDefaults.standard.set(uuidString, forKey: Self.autoconnectPeripheralIdentifierKey)
+        }
+    }
+    /*
     static var autoconnectPeripheral: (identifier: UUID, advertisementData: [String: Any])? {
         get {
-            guard let uuidString = UserDefaults.standard.string(forKey: Settings.autoconnectPeripheralIdentifierKey), let uuid = UUID(uuidString: uuidString), let advertisementData = UserDefaults.standard.dictionary(forKey: Settings.autoconnectPeripheralAdvertisementDataKey) else { return nil}
+            guard let uuidString = UserDefaults.standard.string(forKey: Self.autoconnectPeripheralIdentifierKey), let uuid = UUID(uuidString: uuidString), let advertisementData = UserDefaults.standard.dictionary(forKey: Self.autoconnectPeripheralAdvertisementDataKey) else { return nil}
                         
             return (uuid, advertisementData)
         }
+        
         set {
             let uuidString = newValue?.identifier.uuidString
-            UserDefaults.standard.set(uuidString, forKey: Settings.autoconnectPeripheralIdentifierKey)
-            UserDefaults.standard.set(newValue?.advertisementData, forKey: Settings.autoconnectPeripheralAdvertisementDataKey)
-            
             DLog("Set autoconnect peripheral: \(uuidString ?? "<nil>")")
+
+            UserDefaults.standard.set(uuidString, forKey: Self.autoconnectPeripheralIdentifierKey)
+            UserDefaults.standard.set(newValue?.advertisementData, forKey: Self.autoconnectPeripheralAdvertisementDataKey)
         }
-    }
+    }*/
     
     static func clearAutoconnectPeripheral() {
-        autoconnectPeripheral = nil
+        autoconnectPeripheralUUID = nil
     }
 
     // Common load and save

--- a/Glider/Utils/KeyboardUtils.swift
+++ b/Glider/Utils/KeyboardUtils.swift
@@ -1,0 +1,33 @@
+//
+//  KeyboardUtils.swift
+//  Glider
+//
+//  Created by Antonio García on 26/5/21.
+//
+
+import SwiftUI
+import Combine
+
+/*
+class KeyboardHandler {
+    @State private var keyboardIsShown = false
+    @State private var keyboardHideMonitor: AnyCancellable? = nil
+    @State private var keyboardShownMonitor: AnyCancellable? = nil
+    
+    func setupKeyboardMonitors() {
+         keyboardShownMonitor = NotificationCenter.default
+             .publisher(for: UIWindow.keyboardWillShowNotification)
+            .sink { _ in if !self.keyboardIsShown { keyboardIsShown = true } }
+         
+         keyboardHideMonitor = NotificationCenter.default
+             .publisher(for: UIWindow.keyboardWillHideNotification)
+            .sink { _ in if self.keyboardIsShown { keyboardIsShown = false } }
+     }
+     
+     func dismantleKeyboarMonitors() {
+         keyboardHideMonitor?.cancel()
+         keyboardShownMonitor?.cancel()
+     }
+
+}
+*/

--- a/Glider/ViewModels/FileChooserViewModel.swift
+++ b/Glider/ViewModels/FileChooserViewModel.swift
@@ -13,10 +13,10 @@ class FileChooserViewModel: ObservableObject {
     @Published var directory = ""
     @Published var isTransmiting = false
 
-    private var adafruitBoard: AdafruitBoard?
+    private var fileTransferClient: FileTransferClient?
     
-    func setup(adafruitBoard: AdafruitBoard?, directory: String) {
-        self.adafruitBoard = adafruitBoard
+    func setup(fileTransferClient: FileTransferClient?, directory: String) {
+        self.fileTransferClient = fileTransferClient
         
         // Clean directory name
         let directoryName = FileTransferUtils.pathRemovingFilename(path: directory)
@@ -31,7 +31,7 @@ class FileChooserViewModel: ObservableObject {
         entries.removeAll()
         isTransmiting = true
         
-        adafruitBoard?.listDirectory(path: directory) { [weak self] result in
+        fileTransferClient?.listDirectory(path: directory) { [weak self] result in
             guard let self = self else { return }
             
             DispatchQueue.main.async {
@@ -55,9 +55,11 @@ class FileChooserViewModel: ObservableObject {
     }
     
     func makeDirectory(path: String) {
-        print("makeDirectory: \(path)")
+        // Make sure that the path ends with the separator
+        let pathEndingWithSeparator = path.hasSuffix("/") ? path : path.appending("/")
+        print("makeDirectory: \(pathEndingWithSeparator)")
         isTransmiting = true
-        adafruitBoard?.makeDirectory(path: path) { [weak self] result in
+        fileTransferClient?.makeDirectory(path: pathEndingWithSeparator) { [weak self] result in
             guard let self = self else { return }
             
             DispatchQueue.main.async {
@@ -97,7 +99,7 @@ class FileChooserViewModel: ObservableObject {
             print("delete: \(offset) - \(filename)")
 
             isTransmiting = true
-            adafruitBoard?.deleteFile(path: filename) { [weak self]  result in
+            fileTransferClient?.deleteFile(path: filename) { [weak self]  result in
                 guard let self = self else { return }
                 
                 DispatchQueue.main.async {

--- a/Glider/ViewModels/RootViewModel.swift
+++ b/Glider/ViewModels/RootViewModel.swift
@@ -17,11 +17,15 @@ class RootViewModel: ObservableObject {
         case todo
     }
     
-    @Published var destination: Destination = AppEnvironment.isRunningTests ? .test : .main
+    @Published var destination: Destination = AppEnvironment.isRunningTests ? .test : .startup
     
     
     // MARK: - Actions
     func gotoMain() {
         destination = .main
+    }
+    
+    func gotoStartup() {
+        destination = .startup
     }
 }

--- a/Glider/ViewModels/StartupViewModel.swift
+++ b/Glider/ViewModels/StartupViewModel.swift
@@ -8,11 +8,17 @@
 import UIKit
 
 class StartupViewModel: ObservableObject {
-
+    // Config
+    private static let kMaxTimeToWaitForBleSupport: TimeInterval = 1.0
+    private static let kServicesToReconnect = [BlePeripheral.kFileTransferServiceUUID]
+    private static let kReconnectTimeout = 2.0
+    
     // Published
     enum ActiveAlert {
         case none
-        case bluetoothError(description: String)
+        case bluetoothUnsupported
+        case fileTransferErrorOnReconnect
+        //case bluetoothError(description: String)
         
         var isActive: Bool {
             switch self {
@@ -20,15 +26,105 @@ class StartupViewModel: ObservableObject {
             default: return true
             }
         }
+        
+        mutating func setInactive() {
+            self = .none
+        }
     }
     
     @Published var activeAlert: ActiveAlert = .none
+    @Published var isRestoringConnection = false
+    @Published var isStartupFinished = false
+    
+    // Data
+    private let bleSupportSemaphore = DispatchSemaphore(value: 0)
+    private var startTime: CFAbsoluteTime!
+    
+    deinit {
+        registerAutoReconnectNotifications(enabled: false)
+    }
     
     func setupBluetooth() {
-        // TODO: check Bluetooth status
-        // TODO: reconnect to known peripheral
+        startTime = CFAbsoluteTimeGetCurrent()
+        
+        // check Bluetooth status
+        let bleState = BleManager.shared.state
+        DLog("Initial bluetooth state: \(bleState.rawValue)")
+        if bleState == .unknown || bleState == .resetting {
+            registerBleStateNotifications(enabled: true)
 
+            let semaphoreResult = bleSupportSemaphore.wait(timeout: .now() + Self.kMaxTimeToWaitForBleSupport)
+            if semaphoreResult == .timedOut {
+                DLog("Bluetooth support check time-out. status: \(BleManager.shared.state.rawValue)")
+            }
+
+            registerBleStateNotifications(enabled: false)
+        }
         
-        
+        DispatchQueue.main.async {
+            self.checkBleSupport()
+        }
+
+        registerAutoReconnectNotifications(enabled: true)
+    }
+    
+    // MARK: - Check Ble Support
+    private func checkBleSupport() {
+        if BleManager.shared.state == .unsupported {
+            DLog("Bluetooth unsupported")
+            self.activeAlert = .bluetoothUnsupported
+        }
+        else {
+            AppState.shared.startAutoReconnect()
+            AppState.shared.forceReconnect()
+        }
+    }
+    
+    // MARK: - Notifications
+    private var didUpdateBleStateObserver: NSObjectProtocol?
+
+    private func registerBleStateNotifications(enabled: Bool) {
+        let notificationCenter = NotificationCenter.default
+        if enabled {
+            didUpdateBleStateObserver = notificationCenter.addObserver(forName: .didUpdateBleState, object: nil, queue: nil) { [weak self] _ in
+                // Status received. Continue executing...
+                DLog("Bluetooth status received: \(BleManager.shared.state.rawValue)")
+                self?.bleSupportSemaphore.signal()
+             }
+        } else {
+            if let didUpdateBleStateObserver = didUpdateBleStateObserver {notificationCenter.removeObserver(didUpdateBleStateObserver)}
+        }
+    }
+    
+    private weak var willReconnectToKnownPeripheralObserver: NSObjectProtocol?
+    private weak var didReconnectToKnownPeripheralObserver: NSObjectProtocol?
+    private weak var didFailToReconnectToKnownPeripheralObserver: NSObjectProtocol?
+    
+    private func registerAutoReconnectNotifications(enabled: Bool) {
+        if enabled {
+            willReconnectToKnownPeripheralObserver = NotificationCenter.default.addObserver(forName: .willReconnectToKnownPeripheral, object: nil, queue: .main, using: { [weak self] notification in self?.willReconnectToKnownPeripheral(notification)})
+            didReconnectToKnownPeripheralObserver = NotificationCenter.default.addObserver(forName: .didReconnectToKnownPeripheral, object: nil, queue: .main, using: { [weak self] notification in self?.didReconnectToKnownPeripheral(notification)})
+            didFailToReconnectToKnownPeripheralObserver = NotificationCenter.default.addObserver(forName: .didFailToReconnectToKnownPeripheral, object: nil, queue: .main, using: { [weak self] notification in self?.didFailToReconnectToKnownPeripheral(notification)})
+        } else {
+            if let willReconnectToKnownPeripheralObserver = willReconnectToKnownPeripheralObserver {NotificationCenter.default.removeObserver(willReconnectToKnownPeripheralObserver)}
+            if let didReconnectToKnownPeripheralObserver = didReconnectToKnownPeripheralObserver {NotificationCenter.default.removeObserver(didReconnectToKnownPeripheralObserver)}
+            if let didFailToReconnectToKnownPeripheralObserver = didFailToReconnectToKnownPeripheralObserver {NotificationCenter.default.removeObserver(didFailToReconnectToKnownPeripheralObserver)}
+        }
+    }
+    
+    
+    private func willReconnectToKnownPeripheral(_ notification: Notification) {
+        DLog("willReconnectToKnownPeripheral")
+        isRestoringConnection = true
+    }
+
+    private func didReconnectToKnownPeripheral(_ notification: Notification) {
+        DLog("didReconnectToKnownPeripheral")
+        self.isStartupFinished = true
+    }
+
+    private func didFailToReconnectToKnownPeripheral(_ notification: Notification) {
+        DLog("didFailToReconnectToKnownPeripheral")
+        self.isStartupFinished = true
     }
 }

--- a/Glider/Views/AutoConnectView.swift
+++ b/Glider/Views/AutoConnectView.swift
@@ -13,7 +13,7 @@ struct AutoConnectView: View {
     
     var body: some View {
         
-        NavigationLink(destination: FileTransferView(adafruitBoard: model.adafruitBoard), tag: .fileTransfer, selection: $model.destination) { EmptyView() }
+        NavigationLink(destination: FileTransferView(fileTransferClient: AppState.shared.fileTransferClient), tag: .fileTransfer, selection: $model.destination) { EmptyView() }
         
         VStack {
             Spacer()

--- a/Glider/Views/FileChooserView.swift
+++ b/Glider/Views/FileChooserView.swift
@@ -13,7 +13,7 @@ struct FileChooserView: View {
     @State private var showNewDirectoryDialog = false
     
     @Binding var directory: String
-    var adafruitBoard: AdafruitBoard?
+    var fileTransferClient: FileTransferClient?
     
     var body: some View {
         VStack {
@@ -113,7 +113,7 @@ struct FileChooserView: View {
         }
         .defaultBackground(hidesKeyboardOnTap: true)
         .onAppear {
-            model.setup(adafruitBoard: adafruitBoard, directory: directory)
+            model.setup(fileTransferClient: fileTransferClient, directory: directory)
         }
         .alert(isPresented: $showNewDirectoryDialog, TextFieldAlert(title: "New Directory", message: "Enter name for the new directory") { directoryName in
             if let directoryName = directoryName {
@@ -145,6 +145,6 @@ struct FileChooserView: View {
 
 struct DirectoryChooserView_Previews: PreviewProvider {
     static var previews: some View {
-        FileChooserView(directory: .constant("/"), adafruitBoard: nil)
+        FileChooserView(directory: .constant("/"), fileTransferClient: nil)
     }
 }

--- a/Glider/Views/MainView.swift
+++ b/Glider/Views/MainView.swift
@@ -17,7 +17,7 @@ struct MainView: View {
                 AutoConnectView(isVisible: $isAutoConnectVisible)
             }
             //.defaultBackground()
-            .navigationViewStyle(StackNavigationViewStyle())
+            //.navigationViewStyle(StackNavigationViewStyle())
             .onAppear {
                 // onAppear doesnt work on navigationItem so pass the onAppear/onDissapear via a binding variable: https://developer.apple.com/forums/thread/655338
                 DispatchQueue.main.async {

--- a/Glider/Views/RootView.swift
+++ b/Glider/Views/RootView.swift
@@ -21,6 +21,7 @@ struct RootView: View {
                 TodoView()
             }
         }
+        .environmentObject(model)
    
     }
 }

--- a/Glider/Views/StartupView.swift
+++ b/Glider/Views/StartupView.swift
@@ -10,20 +10,68 @@ import SwiftUI
 struct StartupView: View {
     @StateObject private var model = StartupViewModel()
     @EnvironmentObject var rootViewModel: RootViewModel
-  
+    
     var body: some View {
-        ZStack {
-            
+        VStack {
+            Text("Restoring Connection...")
+                .foregroundColor(Color.white)
+                .if(!model.isRestoringConnection) {
+                    $0.hidden()
+                }
             ProgressView()
                 .scaleEffect(1.5)
                 .progressViewStyle(CircularProgressViewStyle(tint: Color.white))
         }
         .defaultBackground()
-        .onAppear() {
+        .modifier(StartupAlerts(model: model))
+        .onAppear {
             model.setupBluetooth()
+        }
+        .onChange(of: model.isStartupFinished) { isStartupFinished in
+            if isStartupFinished {
+                rootViewModel.gotoMain()
+            }
+        }
+    }
+    
+    private struct StartupAlerts: ViewModifier {
+        @ObservedObject var model: StartupViewModel
+
+        private var isAlertPresented: Binding<Bool> { Binding(
+            get: { self.model.activeAlert.isActive },
+            set: { if !$0 { self.model.activeAlert.setInactive() } }
+        )
+        }
+        
+        func body(content: Content) -> some View {
+            content
+                .alert(isPresented: isAlertPresented, content: {
+                    switch model.activeAlert {
+                    case .bluetoothUnsupported:
+                        return Alert(
+                            title: Text("Error"),
+                            message: Text("This device doesn't support Bluetooth Low Energy which is needed to connect to Bluefruit devices"),
+                            dismissButton: .cancel(Text("Ok")) {
+                                model.setupBluetooth()
+                            })
+                        
+                    case .fileTransferErrorOnReconnect:
+                        return Alert(
+                            title: Text("Error"),
+                            message: Text("Error initializing FileTransfer service"),
+                            dismissButton: .cancel(Text("Ok")) {
+                                model.setupBluetooth()
+                            })
+                        
+                    case .none:
+                        return Alert(title: Text("undefined"))
+                    }
+                })
         }
     }
 }
+
+
 
 struct StartupView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Readme.md
+++ b/Readme.md
@@ -37,13 +37,13 @@ Currently we have some code that needs to be cleaned from Circuit Playground tha
 
 - **readFile**: Given a full path, returns the full contents of the file
 
-		func readFile(path: String, completion: ((Result<Data, Error>) -> Void)?)
+		func readFile(path: String, progress: ProgressHandler? = nil, completion: ((Result<Data, Error>) -> Void)?) {
 		
 	completion is called with  *.success* and the binary *Data* of the file or *.failure* with an *Error*
 
 - **writeFile**: Writes the content to the given full path. If the file exists, it will be overwritten.
 
-		func writeFile(path: String, data: Data, completion: ((Result<Void, Error>) -> Void)?)
+		func writeFile(path: String, data: Data, progress: ProgressHandler? = nil, completion: ((Result<Void, Error>) -> Void)?) {
 		
 	completion is called with *.success* or *.failure* with an *Error*
 


### PR DESCRIPTION
Added: Reconnect on app launch
Added: Reconnect on disconnection (i.e. writing a file)
Added: Delete reconnect informacion when the user manually disconnects clicking back on the File Transfer screen
Added: Progress bar to read and write operations
Fixed: add trailing slash when creating a directory
Updated: readme.md to reflect the changes on the read and write commands that now have a progress handler