### PR TITLE
Release candidate 2

### DIFF
--- a/FileTransferClient/Sources/FileTransferClient/AdafruitKit/Ble/AdafruitSensors/BleDataProcessingQueue.swift
+++ b/FileTransferClient/Sources/FileTransferClient/AdafruitKit/Ble/AdafruitSensors/BleDataProcessingQueue.swift
@@ -52,7 +52,7 @@ class DataProcessingQueue {
     }
     
     func processQueue(receivedData: Data?, processingHandler: ((Data)->Int)) {
-        // Don't append more data, till the delegate has finished processing it
+        // Don't append more data until the delegate has finished processing it
         dataSemaphore.wait()
         
         // Append received data

--- a/FileTransferClient/Sources/FileTransferClient/AdafruitKit/Ble/AdafruitSensors/BlePeripheral+FileTransfer.swift
+++ b/FileTransferClient/Sources/FileTransferClient/AdafruitKit/Ble/AdafruitSensors/BlePeripheral+FileTransfer.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import CoreBluetooth
+import Combine
 
 // TODO: rethink sensors architecture. Extensions are too limiting for complex sensors that need to hook to connect/disconnect events or/and maintain an internal state
 extension BlePeripheral {
@@ -121,13 +122,20 @@ extension BlePeripheral {
         case unknownCommand
         case invalidInternalState
         case statusFailed(code: Int)
+        case disconnected
         
         public var errorDescription: String? {
             switch self {
             case .invalidData: return "invalid data"
             case .unknownCommand: return "unknown command"
             case .invalidInternalState: return "invalid internal state"
-            case .statusFailed(let code): return "status error: \(code)"
+            case .statusFailed(let code):
+                if code == 5 {
+                    return "status error: \(code). Filesystem in read-only mode"
+                } else {
+                    return "status error: \(code)"
+                }
+            case .disconnected: return "disconnected"
             }
         }
     }
@@ -143,6 +151,7 @@ extension BlePeripheral {
         static var adafruitFileTransferListDirectoryStatus: FileTransferListDirectoryStatus?
         static var adafruitFileTransferMakeDirectoryStatus: FileTransferMakeDirectoryStatus?
         static var adafruitFileTransferMoveStatus: FileTransferMoveStatus?
+        static var adafruitFileTransferDisconnectionObserverCancellable: Cancellable?
     }
     
     private var adafruitFileTransferVersion: Int {
@@ -226,11 +235,22 @@ extension BlePeripheral {
         }
     }
     
+    private var adafruitFileTransferDisconnectionObserverCancellable: Cancellable? {
+        get {
+            return objc_getAssociatedObject(self, &CustomPropertiesKeys.adafruitFileTransferDisconnectionObserverCancellable) as? Cancellable
+        }
+        set {
+            objc_setAssociatedObject(self, &CustomPropertiesKeys.adafruitFileTransferDisconnectionObserverCancellable, newValue, .OBJC_ASSOCIATION_RETAIN)
+        }
+    }
+    
     // MARK: - Actions
     func adafruitFileTransferEnable(completion: ((Result<Void, Error>) -> Void)?) {
         
-        adafruitFileTransferDisable()       // Clear any previous data
+        // Clear any previous data
+        adafruitFileTransferDisable()
         
+        // Enable
         self.adafruitServiceEnable(serviceUuid: Self.kFileTransferServiceUUID, versionCharacteristicUUID: Self.kFileTransferVersionCharacteristicUUID, mainCharacteristicUuid: Self.kFileTransferDataCharacteristicUUID) { [weak self] result in
             guard let self = self else { return }
             
@@ -241,7 +261,15 @@ extension BlePeripheral {
                 self.adafruitFileTransferVersion = version
                 self.adafruitFileTransferDataCharacteristic = characteristic
                 
+                // Set notify
                 self.adafruitServiceSetNotifyResponse(characteristic: characteristic, responseHandler: self.receiveFileTransferData, completion: completion)
+                
+                // Detect disconnection to clear internal state
+                self.adafruitFileTransferDisconnectionObserverCancellable = NotificationCenter.default.publisher(for: .didDisconnectFromPeripheral)
+                    .filter {  ($0.userInfo?[BleManager.NotificationUserInfoKey.uuid.rawValue] as? UUID) == self.identifier }
+                    .sink { [weak self] _ in
+                        self?.adafruitFileTransferDisable()
+                    }
                 
             case let .failure(error):
                 self.adafruitFileTransferDataCharacteristic = nil
@@ -255,16 +283,31 @@ extension BlePeripheral {
     }
     
     func adafruitFileTransferDisable() {
+        DLog("adafruitFileTransferDisable: \(self.debugName) ")
+        
         // Clear all internal data
         adafruitFileTransferVersion = CustomPropertiesKeys.adafruitFileTransferVersion
         adafruitFileTransferDataCharacteristic = nil
         adafruitFileTransferDataProcessingQueue = nil
+        adafruitFileTransferDisconnectionObserverCancellable = nil
         
+        // Clear all internal variables for commands, sending an error to the completion handler if it was still executing
+        adafruitFileTransferReadStatus?.completion?(.failure(FileTransferError.disconnected))
         adafruitFileTransferReadStatus = nil
+
+        adafruitFileTransferWriteStatus?.completion?(.failure(FileTransferError.disconnected))
         adafruitFileTransferWriteStatus = nil
+
+        adafruitFileTransferDeleteStatus?.completion?(.failure(FileTransferError.disconnected))
         adafruitFileTransferDeleteStatus = nil
+        
+        adafruitFileTransferListDirectoryStatus?.completion?(.failure(FileTransferError.disconnected))
         adafruitFileTransferListDirectoryStatus = nil
+        
+        adafruitFileTransferMakeDirectoryStatus?.completion?(.failure(FileTransferError.disconnected))
         adafruitFileTransferMakeDirectoryStatus = nil
+        
+        adafruitFileTransferMoveStatus?.completion?(.failure(FileTransferError.disconnected))
         adafruitFileTransferMoveStatus = nil
     }
     
@@ -406,6 +449,11 @@ extension BlePeripheral {
     }
     
     private func sendCommand(data: Data, completion: ((Result<Void, Error>) -> Void)?) {
+        guard self.state == .connected else {
+            completion?(.failure(FileTransferError.disconnected))
+            return
+        }
+        
         guard let adafruitFileTransferDataCharacteristic = adafruitFileTransferDataCharacteristic else {
             completion?(.failure(PeripheralAdafruitError.invalidCharacteristic))
             return

--- a/FileTransferClient/Sources/FileTransferClient/AdafruitKit/Ble/AdafruitSensors/BlePeripheral+FileTransfer.swift
+++ b/FileTransferClient/Sources/FileTransferClient/AdafruitKit/Ble/AdafruitSensors/BlePeripheral+FileTransfer.swift
@@ -12,7 +12,7 @@ import Combine
 // TODO: rethink sensors architecture. Extensions are too limiting for complex sensors that need to hook to connect/disconnect events or/and maintain an internal state
 extension BlePeripheral {
     // Config
-    private static let kDebugMessagesEnabled = AppEnvironment.isDebug && true
+    private static let kDebugMessagesEnabled = AppEnvironment.isDebug && false
     
     // Constants
     public static let kFileTransferServiceUUID = CBUUID(string: "FEBB")
@@ -481,12 +481,6 @@ extension BlePeripheral {
             
             processDataQueue(receivedData: receivedData)
             
-            /*
-            var remainingData: Data? = data
-            while remainingData != nil && remainingData!.count > 0 {
-                remainingData = decodeResponseChunk(data: remainingData!)
-            }*/
-                                
         case .failure(let error):
             DLog("receiveFileTransferData error: \(error)")
         }
@@ -657,7 +651,7 @@ extension BlePeripheral {
 
     private func decodeDeleteFile(data: Data) -> Int {
         guard let adafruitFileTransferDeleteStatus = adafruitFileTransferDeleteStatus else {
-            DLog("Error: delete invalid internal status. Invalidating all received data..."); return Int.max }
+            DLog("Warning: unexpected delete result received. Invalidating all received data..."); return Int.max }
         let completion = adafruitFileTransferDeleteStatus.completion
 
         guard data.count >= Self.deleteFileResponseHeaderSize else { return 0 }      // Header has not been fully received yet
@@ -677,7 +671,7 @@ extension BlePeripheral {
     }
     
     private func decodeMakeDirectory(data: Data) -> Int {
-        guard let adafruitFileTransferMakeDirectoryStatus = adafruitFileTransferMakeDirectoryStatus else { DLog("Error: makeDirectory invalid internal status. Invalidating all received data..."); return Int.max }
+        guard let adafruitFileTransferMakeDirectoryStatus = adafruitFileTransferMakeDirectoryStatus else { DLog("Warning: unexpected makeDirectory result received. Invalidating all received data..."); return Int.max }
         let completion = adafruitFileTransferMakeDirectoryStatus.completion
 
         guard data.count >= makeDirectoryResponseHeaderSize(protocolVersion: adafruitFileTransferVersion) else { return 0 }      // Header has not been fully received yet
@@ -704,7 +698,7 @@ extension BlePeripheral {
     
     private func decodeListDirectory(data: Data) -> Int {
         guard let adafruitFileTransferListDirectoryStatus = adafruitFileTransferListDirectoryStatus else {
-            DLog("Error: list invalid internal status. Invalidating all received data..."); return Int.max }
+            DLog("Warning: unexpected list result received. Invalidating all received data..."); return Int.max }
         let completion = adafruitFileTransferListDirectoryStatus.completion
         
         let headerSize = listDirectoryResponseHeaderSize(protocolVersion: adafruitFileTransferVersion)
@@ -772,31 +766,3 @@ extension BlePeripheral {
         return packetSize
     }
 }
-
-/*
-// MARK: - Codable extension for DirectoryEntry
-extension BlePeripheral.DirectoryEntry.EntryType: Encodable {
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        switch self {
-        case .directory:
-            try container.encodeNil(forKey: .directory)
-        case .file(let size):
-            try container.encode(size, forKey: .file)
-        }
-    }
-}
-
-extension BlePeripheral.DirectoryEntry.EntryType: Decodable {
-    public init(from decoder: Decoder) throws {
-        if let size = try? decoder.singleValueContainer().decode(Int.self) {
-            self = .file(size: size)
-        }
-        else {
-            self = .directory
-        }
-    }
-}
-
-extension BlePeripheral.DirectoryEntry: Codable { }
-*/

--- a/FileTransferClient/Sources/FileTransferClient/AdafruitKit/Ble/BleCentralMode/BleManager.swift
+++ b/FileTransferClient/Sources/FileTransferClient/AdafruitKit/Ble/BleCentralMode/BleManager.swift
@@ -229,7 +229,7 @@ public class BleManager: NSObject {
         if let blePeripheral = peripheralsFound[peripheralIdentifier] {
             centralManager?.cancelPeripheralConnection(blePeripheral.peripheral)
         } else {
-            DLog("simulate disconnection")
+            //DLog("simulate disconnection")
             // The blePeripheral is available on peripheralsFound, so simulate the disconnection
             NotificationCenter.default.post(name: .didDisconnectFromPeripheral, object: nil, userInfo: [NotificationUserInfoKey.uuid.rawValue: peripheralIdentifier])
         }

--- a/Glider.xcodeproj/project.pbxproj
+++ b/Glider.xcodeproj/project.pbxproj
@@ -920,7 +920,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Glider/Glider.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_ASSET_PATHS = "\"Glider/Preview Content\"";
 				DEVELOPMENT_TEAM = 2X94RM7457;
 				ENABLE_PREVIEWS = YES;
@@ -930,7 +930,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_SWIFT_FLAGS = "-D SIMULATEBLUETOOTH";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adafruit.Glider.simulatebluetooth;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -947,7 +947,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Glider/Glider.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_ASSET_PATHS = "\"Glider/Preview Content\"";
 				DEVELOPMENT_TEAM = 2X94RM7457;
 				ENABLE_PREVIEWS = YES;
@@ -957,7 +957,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_SWIFT_FLAGS = "-D SIMULATEBLUETOOTH";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adafruit.Glider.simulatebluetooth;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1091,7 +1091,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Glider/Glider.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_ASSET_PATHS = "\"Glider/Preview Content\"";
 				DEVELOPMENT_TEAM = 2X94RM7457;
 				ENABLE_PREVIEWS = YES;
@@ -1101,7 +1101,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adafruit.Glider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -1117,7 +1117,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Glider/Glider.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_ASSET_PATHS = "\"Glider/Preview Content\"";
 				DEVELOPMENT_TEAM = 2X94RM7457;
 				ENABLE_PREVIEWS = YES;
@@ -1127,7 +1127,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adafruit.Glider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -1190,7 +1190,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 2X94RM7457;
 				INFOPLIST_FILE = GliderFileProviderUI/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -1199,7 +1199,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adafruit.Glider.GliderFileProviderUI;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1212,7 +1212,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 2X94RM7457;
 				INFOPLIST_FILE = GliderFileProviderUI/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -1221,7 +1221,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adafruit.Glider.GliderFileProviderUI;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1235,7 +1235,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = GliderFileProvider/GliderFileProvider.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 2X94RM7457;
 				INFOPLIST_FILE = GliderFileProvider/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -1244,7 +1244,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adafruit.Glider.GliderFileProvider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1260,7 +1260,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = GliderFileProvider/GliderFileProvider.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEVELOPMENT_TEAM = 2X94RM7457;
 				INFOPLIST_FILE = GliderFileProvider/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -1269,7 +1269,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adafruit.Glider.GliderFileProvider;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Glider.xcodeproj/project.pbxproj
+++ b/Glider.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		A98B67D8271BA83E00787A02 /* FileCommandsStatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98B67D7271BA83E00787A02 /* FileCommandsStatusBarView.swift */; };
 		A98B67DA271D6D3800787A02 /* PeripheralChooserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98B67D9271D6D3800787A02 /* PeripheralChooserView.swift */; };
 		A98B67DC271D999200787A02 /* FileMoveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98B67DB271D999100787A02 /* FileMoveView.swift */; };
+		A9C20E512773605E003DCA44 /* Result+SimpleCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C20E502773605E003DCA44 /* Result+SimpleCheck.swift */; };
 		A9D6E353271890870048EB12 /* FileExplorerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D6E352271890870048EB12 /* FileExplorerView.swift */; };
 		A9D6E35527190A2E0048EB12 /* TransmissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D6E35427190A2E0048EB12 /* TransmissionStatus.swift */; };
 		A9D6E357271918EC0048EB12 /* FileEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D6E356271918EC0048EB12 /* FileEditView.swift */; };
@@ -207,6 +208,7 @@
 		A98B67D7271BA83E00787A02 /* FileCommandsStatusBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCommandsStatusBarView.swift; sourceTree = "<group>"; };
 		A98B67D9271D6D3800787A02 /* PeripheralChooserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeripheralChooserView.swift; sourceTree = "<group>"; };
 		A98B67DB271D999100787A02 /* FileMoveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMoveView.swift; sourceTree = "<group>"; };
+		A9C20E502773605E003DCA44 /* Result+SimpleCheck.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Result+SimpleCheck.swift"; sourceTree = "<group>"; };
 		A9D6E352271890870048EB12 /* FileExplorerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerView.swift; sourceTree = "<group>"; };
 		A9D6E35427190A2E0048EB12 /* TransmissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransmissionStatus.swift; sourceTree = "<group>"; };
 		A9D6E356271918EC0048EB12 /* FileEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEditView.swift; sourceTree = "<group>"; };
@@ -447,6 +449,7 @@
 		A947FE7D26543894007A5E5A /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				A9C20E502773605E003DCA44 /* Result+SimpleCheck.swift */,
 				A96D27842687F9DB00D6E247 /* FileProviderUtils.swift */,
 				A9678E9126E91B90003936DC /* UIColor+LightAndDark.swift */,
 			);
@@ -851,6 +854,7 @@
 				A9ED1F2B2687530700B6C27F /* FileProviderItem.swift in Sources */,
 				A9E3CBAE2704D1FB00CD4BA3 /* GliderClient.swift in Sources */,
 				A9ED1F6126878ABF00B6C27F /* FileMetadataCache.swift in Sources */,
+				A9C20E512773605E003DCA44 /* Result+SimpleCheck.swift in Sources */,
 				A96D27862687FA1800D6E247 /* FileProviderUtils.swift in Sources */,
 				A9ED1F2D2687530700B6C27F /* FileProviderEnumerator.swift in Sources */,
 			);

--- a/Glider.xcodeproj/xcshareddata/xcschemes/GliderFileProvider.xcscheme
+++ b/Glider.xcodeproj/xcshareddata/xcschemes/GliderFileProvider.xcscheme
@@ -59,7 +59,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
-      launchStyle = "0"
+      launchStyle = "1"
       askForAppToLaunch = "Yes"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -70,7 +70,7 @@
       <RemoteRunnable
          runnableDebuggingMode = "1"
          BundleIdentifier = "com.apple.DocumentsApp"
-         RemotePath = "/var/containers/Bundle/Application/290D8A99-E2D7-4DC4-9E37-400AAD3984B3/Files.app">
+         RemotePath = "/var/containers/Bundle/Application/E5C34E5D-20AB-4A94-8FCA-9C5E68D787E4/Files.app">
       </RemoteRunnable>
       <MacroExpansion>
          <BuildableReference

--- a/Glider/Utils/Result+SimpleCheck.swift
+++ b/Glider/Utils/Result+SimpleCheck.swift
@@ -1,0 +1,12 @@
+//
+//  Result+SimpleCheck.swift
+//
+//  Created by Antonio García on 15/8/21.
+//
+
+import Foundation
+
+extension Result {
+    var isSuccess: Bool { if case .success = self { return true } else { return false } }
+    var isError: Bool { return !isSuccess }
+}

--- a/Glider/ViewModels/FileSystemViewModel.swift
+++ b/Glider/ViewModels/FileSystemViewModel.swift
@@ -10,7 +10,6 @@ import FileTransferClient
 
 class FileSystemViewModel: FileCommandsViewModel {
     
-    
     // MARK: - Lifecycle
     func setup(directory: String, fileTransferClient: FileTransferClient) {
         // Clean directory name

--- a/Glider/Views/FileExplorerView.swift
+++ b/Glider/Views/FileExplorerView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 import FileTransferClient
 
 struct FileExplorerView: View {
-    
     @EnvironmentObject private var connectionManager: FileTransferConnectionManager
+    
     @StateObject private var model = FileSystemViewModel()
     @State private var path = FileTransferPathUtils.rootDirectory
     @State private var isShowingPeripheralChooser = false
@@ -28,21 +28,9 @@ struct FileExplorerView: View {
                 VStack {
                     // Peripheral
                     VStack(alignment: .leading, spacing: 1) {
-                        //HStack(alignment: .bottom) {
-                            Text("Selected peripheral")
-                        /*
-                            Spacer()
-                            Text("Reconnecting...")
-                                .padding(.horizontal, 4)
-                                .padding(.vertical, 2)
-                                .background(Color.orange)
-                                .cornerRadius(8)
-                                .opacity(connectionManager.isSelectedPeripheralReconnecting ? 1 : 0)
-                                .animation(.default, value: connectionManager.isSelectedPeripheralReconnecting)
-                            
-                        }*/
-                        .foregroundColor(.white)
-                        .font(.caption2)
+                        Text("Selected peripheral")
+                            .foregroundColor(.white)
+                            .font(.caption2)
                         
                         Button(action: {
                             isShowingPeripheralChooser.toggle()

--- a/Glider/Views/LogView.swift
+++ b/Glider/Views/LogView.swift
@@ -91,7 +91,7 @@ struct LogView: View {
             .sheet(isPresented: $isShareSheetPresented, onDismiss: nil) {
                 let entries = showFileProviderLog ? logManagerFileProvider.entries : logManager.entries
                 let text = shareText(entries: entries)
-                let filename = "\(showFileProviderLog ? "AppLog":"FileProviderLog")_b\(AppEnvironment.buildNumber ?? "-")"
+                let filename = "\(showFileProviderLog ? "FileProviderLog":"AppLog")_b\(AppEnvironment.buildNumber ?? "-")"
                 if let data = text.data(using: .utf8), let textUrl = saveToTemporaryDirectory(data: data, resourceName: filename, fileExtension: "txt") {
                     ActivityViewController(activityItems: [textUrl])
                 }

--- a/GliderFileProvider/GliderClient.swift
+++ b/GliderFileProvider/GliderClient.swift
@@ -8,16 +8,16 @@
 import Foundation
 import FileTransferClient
 
+/// Helper class to serialize FileTransfer operations
+/// It will check that the peripheral is connected and properly initialized before executing each operation
 class GliderClient {
-    // Config
-    private static let maxTimeToWaitForBleSupport: TimeInterval = 1.0
-    private static let willDeviceDisconnectAfterWrite = true    // If the device automatically disconnects after a write, don't signal on write. Wait for the disconnection to happen
-
+    // Enums
     enum GliderError: LocalizedError {
         case bluetoothNotSupported
         case connectionFailed
         case invalidInternalState
         case undefinedFileProviderItem(identifier: String)
+        case cancelled
     }
 
     // Singleton (used to manage concurrency)
@@ -34,110 +34,272 @@ class GliderClient {
     }
 
     // Data
-    private let identifier: UUID
-    private let fileTransferSemaphore = DispatchSemaphore(value: 1)
+    private lazy var operationsQueue: OperationQueue = {
+        var queue = OperationQueue()
+        queue.name = "Operations queue for \(identifier)"
+        queue.maxConcurrentOperationCount = 1
+        return queue
+    }()
     
-    // MARK: -
+    // MARK: - Lifecycle
+    private let identifier: UUID
+    
     private init(identifier: UUID) {
         self.identifier = identifier
     }
     
-    // MARK: - Commands (with semaphore to avoid concurrent requests)
+    // MARK: - Read
     func readFile(path: String, progress: FileTransferClient.ProgressHandler? = nil, completion: ((Result<Data, Error>) -> Void)?) {
-        fileTransferSemaphore.wait()
-        setupFileTransferIfNeeded { result in
-            switch result {
-            case .success(let client):
-                client.readFile(path: path, progress: progress) {
-                    self.fileTransferSemaphore.signal()
-                    completion?($0)
-                }
-            case .failure(let error):
-                self.fileTransferSemaphore.signal()
-                completion?(.failure(error))
-            }
-        }
+        
+        let operation = GliderReadFileOperation(identifier: identifier, path: path, progress: progress, completion: completion)
+        DLog("GliderClient: add read operation \(path)")
+        operationsQueue.addOperation(operation)
     }
     
-    func writeFile(path: String, data: Data, progress: FileTransferClient.ProgressHandler? = nil, completion: ((Result<Void, Error>) -> Void)?) {
-        DLog("writeFile requested: \(path)")
-        fileTransferSemaphore.wait()
-        DLog("writeFile setup: \(path)")
-        setupFileTransferIfNeeded { result in
-            switch result {
-            case .success(let client):
-                client.writeFile(path: path, data: data, progress: progress) { result in
-                    switch result {
-                    case .success:
-                        DLog("writeFile finished successfully. Waiting for disconnect")
-                        if !Self.willDeviceDisconnectAfterWrite {
-                            self.fileTransferSemaphore.signal()
-                        }
-                        completion?(.success(()))
-                        
-                    case .failure(let error):
-                        DLog("writeFile finished with error")
-                        self.fileTransferSemaphore.signal()
-                        completion?(.failure(error))
+    private class GliderReadFileOperation: Operation {
+        private let identifier: UUID
+        
+        private let path: String
+        private let progress: FileTransferClient.ProgressHandler?
+        private let completion: ((Result<Data, Error>) -> Void)?
+        
+        init(identifier: UUID, path: String, progress: FileTransferClient.ProgressHandler? = nil, completion: ((Result<Data, Error>) -> Void)?) {
+            self.identifier = identifier
+            self.path = path
+            self.progress = progress
+            self.completion = completion
+            super.init()
+        }
+        
+        override func main() {
+            guard !isCancelled else { completion?(.failure(GliderError.cancelled)); return }
+            
+            //DLog("GliderClient: read start")
+            let syncSemaphore = DispatchSemaphore(value: 0)     // Make the main() function synchronous
+            GliderClient.setupFileTransferIfNeeded(identifier: identifier) { [weak self] result in
+                guard let self = self else { syncSemaphore.signal(); return }
+
+                switch result {
+                case .success(let client):
+                    guard !self.isCancelled else { self.completion?(.failure(GliderError.cancelled)); syncSemaphore.signal(); return }
+                    //DLog("GliderClient: read prepared: \(result.isSuccess)")
+                    client.readFile(path: self.path, progress: self.progress) { [weak self] result in
+                        //DLog("GliderClient: read finished: \(result.isSuccess)")
+                        self?.completion?(result)
+                        syncSemaphore.signal()
                     }
+                case .failure(let error):
+                    self.completion?(.failure(error))
+                    syncSemaphore.signal()
                 }
-            case .failure(let error):
-                DLog("writeFile setup finished with error")
-                self.fileTransferSemaphore.signal()
-                completion?(.failure(error))
             }
+            
+            syncSemaphore.wait()        // Operation main() should return when completed
         }
     }
     
+    // MARK: - Write
+    func writeFile(path: String, data: Data, progress: FileTransferClient.ProgressHandler? = nil, completion: ((Result<Void, Error>) -> Void)?) {
+        let operation = GliderWriteFileOperation(identifier: identifier, path: path, data: data, progress: progress, completion: completion)
+        DLog("GliderClient: add write operation \(path)")
+        operationsQueue.addOperation(operation)
+    }
+    
+    private class GliderWriteFileOperation: Operation {
+        private let identifier: UUID
+        
+        private let path: String
+        private let data: Data
+        private let progress: FileTransferClient.ProgressHandler?
+        private let completion: ((Result<Void, Error>) -> Void)?
+        
+        init(identifier: UUID, path: String, data: Data, progress: FileTransferClient.ProgressHandler? = nil, completion: ((Result<Void, Error>) -> Void)?) {
+            self.identifier = identifier
+            self.path = path
+            self.data = data
+            self.progress = progress
+            self.completion = completion
+            super.init()
+        }
+        
+        override func main() {
+            guard !isCancelled else { completion?(.failure(GliderError.cancelled)); return }
+            
+            //DLog("GliderClient: write start")
+            let syncSemaphore = DispatchSemaphore(value: 0)     // Make the main() function synchronous
+            GliderClient.setupFileTransferIfNeeded(identifier: identifier) { [weak self] result in
+                guard let self = self else { syncSemaphore.signal(); return }
+                switch result {
+                case .success(let client):
+                    guard !self.isCancelled else { self.completion?(.failure(GliderError.cancelled)); syncSemaphore.signal(); return }
+                    //DLog("GliderClient: write prepared: \(result.isSuccess)")
+                    client.writeFile(path: self.path, data: self.data, progress: self.progress) { [weak self] result in
+                        guard let self = self else { syncSemaphore.signal(); return }
+                        //DLog("GliderClient: write finished: \(result.isSuccess)")
+                        switch result {
+                        case .success:
+                            self.completion?(.success(()))
+
+                        case .failure(let error):
+                            self.completion?(.failure(error))
+                        }
+                        syncSemaphore.signal()
+                    }
+                case .failure(let error):
+                    self.completion?(.failure(error))
+                    syncSemaphore.signal()
+                }
+            }
+            
+            syncSemaphore.wait()        // Operation main() should return when completed
+        }
+    }
+    
+    // MARK: - Delete
     func deleteFile(path: String, completion: ((Result<Void, Error>) -> Void)?) {
-        fileTransferSemaphore.wait()
-        setupFileTransferIfNeeded { result in
-            switch result {
-            case .success(let client):
-                client.deleteFile(path: path) { result in
-                    self.fileTransferSemaphore.signal()
-                    completion?(result)
-                }
-            case .failure(let error):
-                self.fileTransferSemaphore.signal()
-                completion?(.failure(error))
-            }
-        }
+        let operation = GliderDeleteFileOperation(identifier: identifier, path: path, completion: completion)
+        DLog("GliderClient: add delete operation \(path)")
+        operationsQueue.addOperation(operation)
     }
 
-    func makeDirectory(path: String, completion: ((Result<Date?, Error>) -> Void)?) {
-        fileTransferSemaphore.wait()
-        setupFileTransferIfNeeded { result in
-            switch result {
-            case .success(let client):
-                client.makeDirectory(path: path) {
-                    self.fileTransferSemaphore.signal()
-                    completion?($0)
-                }
-            case .failure(let error):
-                self.fileTransferSemaphore.signal()
-                completion?(.failure(error))
-            }
+    private class GliderDeleteFileOperation: Operation {
+        private let identifier: UUID
+        
+        private let path: String
+        private let completion: ((Result<Void, Error>) -> Void)?
+        
+        init(identifier: UUID, path: String, completion: ((Result<Void, Error>) -> Void)?) {
+            self.identifier = identifier
+            self.path = path
+            self.completion = completion
+            super.init()
         }
-    }
-
-    func listDirectory(path: String, completion: ((Result<[BlePeripheral.DirectoryEntry]?, Error>) -> Void)?) {
-        fileTransferSemaphore.wait()
-        setupFileTransferIfNeeded { result in
-            switch result {
-            case .success(let client):
-                client.listDirectory(path: path) {
-                    self.fileTransferSemaphore.signal()
-                    completion?($0)
+        
+        override func main() {
+            guard !isCancelled else { completion?(.failure(GliderError.cancelled)); return }
+            
+            //DLog("GliderClient: delete start")
+            let syncSemaphore = DispatchSemaphore(value: 0)     // Make the main() function synchronous
+            GliderClient.setupFileTransferIfNeeded(identifier: identifier) { [weak self] result in
+                guard let self = self else { syncSemaphore.signal(); return }
+                //DLog("GliderClient: delete prepared: \(result.isSuccess)")
+                switch result {
+                case .success(let client):
+                    guard !self.isCancelled else { self.completion?(.failure(GliderError.cancelled)); syncSemaphore.signal(); return }
+                    
+                    client.deleteFile(path: self.path) { [weak self] result in
+                        //DLog("GliderClient: delete finished: \(result.isSuccess)")
+                        self?.completion?(result)
+                        syncSemaphore.signal()
+                    }
+                case .failure(let error):
+                    self.completion?(.failure(error))
+                    syncSemaphore.signal()
                 }
-            case .failure(let error):
-                self.fileTransferSemaphore.signal()
-                completion?(.failure(error))
             }
+            
+            syncSemaphore.wait()        // Operation main() should return when completed
         }
     }
     
-    private func setupFileTransferIfNeeded(completion: @escaping (Result<FileTransferClient, Error>)->Void) {
+    // MARK: - Make Directory
+    func makeDirectory(path: String, completion: ((Result<Date?, Error>) -> Void)?) {
+        let operation = GliderMakeDirectoryFileOperation(identifier: identifier, path: path, completion: completion)
+        DLog("GliderClient: add make directory operation \(path)")
+        operationsQueue.addOperation(operation)
+    }
+
+    private class GliderMakeDirectoryFileOperation: Operation {
+        private let identifier: UUID
+        
+        private let path: String
+        private let completion: ((Result<Date?, Error>) -> Void)?
+        
+        init(identifier: UUID, path: String, completion: ((Result<Date?, Error>) -> Void)?) {
+            self.identifier = identifier
+            self.path = path
+            self.completion = completion
+            super.init()
+        }
+        
+        override func main() {
+            guard !isCancelled else { completion?(.failure(GliderError.cancelled)); return }
+                        
+            //DLog("GliderClient: make directory start")
+            let syncSemaphore = DispatchSemaphore(value: 0)     // Make the main() function synchronous
+            GliderClient.setupFileTransferIfNeeded(identifier: identifier) { [weak self] result in
+                guard let self = self else { syncSemaphore.signal(); return }
+                //DLog("GliderClient: make directory prepared: \(result.isSuccess)")
+                switch result {
+                case .success(let client):
+                    guard !self.isCancelled else { self.completion?(.failure(GliderError.cancelled)); syncSemaphore.signal(); return }
+                    
+                    client.makeDirectory(path: self.path) { [weak self] result in
+                        //DLog("GliderClient: make directory finished: \(result.isSuccess)")
+                        self?.completion?(result)
+                        syncSemaphore.signal()
+                    }
+                case .failure(let error):
+                    self.completion?(.failure(error))
+                    syncSemaphore.signal()
+                }
+            }
+            
+            syncSemaphore.wait()        // Operation main() should return when completed
+        }
+    }
+    
+    
+    // MARK: - List Directory
+    func listDirectory(path: String, completion: ((Result<[BlePeripheral.DirectoryEntry]?, Error>) -> Void)?) {
+        let operation = GliderListDirectoryFileOperation(identifier: identifier, path: path, completion: completion)
+        DLog("GliderClient: add list directory operation \(path)")
+        operationsQueue.addOperation(operation)
+    }
+
+    private class GliderListDirectoryFileOperation: Operation {
+        private let identifier: UUID
+        
+        private let path: String
+        private let completion: ((Result<[BlePeripheral.DirectoryEntry]?, Error>) -> Void)?
+        
+        init(identifier: UUID, path: String, completion: ((Result<[BlePeripheral.DirectoryEntry]?, Error>) -> Void)?) {
+            self.identifier = identifier
+            self.path = path
+            self.completion = completion
+            super.init()
+        }
+        
+        override func main() {
+            guard !isCancelled else { completion?(.failure(GliderError.cancelled)); return }
+            
+            //DLog("GliderClient: list directory start")
+            let syncSemaphore = DispatchSemaphore(value: 0)     // Make the main() function synchronous
+            GliderClient.setupFileTransferIfNeeded(identifier: identifier) { [weak self] result in
+                guard let self = self else { syncSemaphore.signal(); return }
+                //DLog("GliderClient: list directory prepared: \(result.isSuccess)")
+                switch result {
+                case .success(let client):
+                    guard !self.isCancelled else { self.completion?(.failure(GliderError.cancelled)); syncSemaphore.signal(); return }
+                    
+                    client.listDirectory(path: self.path) { [weak self] result in
+                        //DLog("GliderClient: list directory finished: \(result.isSuccess)")
+                        self?.completion?(result)
+                        syncSemaphore.signal()
+                    }
+                case .failure(let error):
+                    self.completion?(.failure(error))
+                    syncSemaphore.signal()
+                }
+            }
+            
+            syncSemaphore.wait()        // Operation main() should return when completed
+        }
+    }
+
+    
+    // MARK: - Common
+    private static func setupFileTransferIfNeeded(identifier: UUID, completion: @escaping (Result<FileTransferClient, Error>)->Void) {
         let fileTransferClient = FileTransferConnectionManager.shared.fileTransferClient(fromIdentifier: identifier)
         let isReconnecting = FileTransferConnectionManager.shared.isReconnectingPeripheral(withIdentifier: identifier)
         guard fileTransferClient == nil || !fileTransferClient!.isFileTransferEnabled || isReconnecting else {


### PR DESCRIPTION
- Glider: Fix  deadlock when running a command just before disconnection and reconnection
- FileProvider: use a sequential operation queue for waiting operations instead of just a simple semaphore. Fixes problems when multiple operations get queued before the current operation finishes. For example when moving directories with multiple files or/and subdirectories
- FileProvider: Fix invalid path when no peripheral is connected
- Fix wrong filename for the exported log file
