### PR TITLE
API version Update

### DIFF
--- a/Glider.xcodeproj/project.pbxproj
+++ b/Glider.xcodeproj/project.pbxproj
@@ -1191,7 +1191,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Glider/Preview Content\"";
 				DEVELOPMENT_TEAM = 2X94RM7457;
@@ -1221,7 +1221,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adafruit.Glider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1243,7 +1243,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Glider/Preview Content\"";
 				DEVELOPMENT_TEAM = 2X94RM7457;
@@ -1273,7 +1273,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adafruit.Glider;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;

--- a/Glider/AdafruitKit/Wifi/Model/FileTransferWebApiVersion.swift
+++ b/Glider/AdafruitKit/Wifi/Model/FileTransferWebApiVersion.swift
@@ -20,3 +20,40 @@ struct FileTransferWebApiVersion {
     let port: Int
     let ip: String
 }
+
+struct FileInfo: Codable {
+    let name: String
+    let directory: Bool
+    let modifiedNs: Int
+    let fileSize: Int
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case directory
+        case modifiedNs = "modified_ns"
+        case fileSize = "file_size"
+    }
+}
+
+struct FolderInfo: Codable {
+    let files: [FileInfo]
+    let version: Int
+}
+
+struct StorageInfo: Codable {
+    let root: String
+    let free: Int
+    let total: Int
+    let blockSize: Int
+    let writable: Bool
+    let disks: [FolderInfo]
+
+    enum CodingKeys: String, CodingKey {
+        case root
+        case free
+        case total
+        case blockSize = "block_size"
+        case writable
+        case disks = "files"
+    }
+}

--- a/Glider/AdafruitKit/Wifi/Network/FileTransferJsonDeserializer.swift
+++ b/Glider/AdafruitKit/Wifi/Network/FileTransferJsonDeserializer.swift
@@ -37,21 +37,24 @@ extension FileTransferNetwork {
     
     internal func decodeListDirectory(data: Data) -> [DirectoryEntry] {
         let json = JSON(data)
-        
-        var entries = [DirectoryEntry]()
-        for (_, entryJson) in json {
-            let name = entryJson["name"].stringValue
-            let isDirectory = entryJson["directory"].boolValue
-            let fileSize = entryJson["file_size"].intValue
-            let timestamp = entryJson["modified_ns"].int64Value
-
-            let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
-            let entry = DirectoryEntry(name: name, type: isDirectory ? .directory : .file(size: fileSize), modificationDate: date)
+            var entries = [DirectoryEntry]()
             
-            entries.append(entry)
-        }
-        
-        return entries
+
+            if let filesArray = json["files"].array {
+                for entryJson in filesArray {
+                    let name = entryJson["name"].stringValue
+                    let isDirectory = entryJson["directory"].boolValue
+                    let fileSize = entryJson["file_size"].intValue
+                    let modifiedNs = entryJson["modified_ns"].int64Value
+                    let date = Date(timeIntervalSince1970: TimeInterval(modifiedNs / 1_000_000_000)) 
+                    
+                    let entry = DirectoryEntry(name: name, type: isDirectory ? .directory : .file(size: fileSize), modificationDate: date)
+                    
+                    entries.append(entry)
+                }
+            }
+            
+            return entries
     }
 
 }

--- a/Glider/Views/FileExplorerView.swift
+++ b/Glider/Views/FileExplorerView.swift
@@ -49,7 +49,6 @@ struct FileExplorerView: View {
     }
 }
 
-
 private struct FileExplorerBody: View {
     @ObservedObject var model: FileSystemViewModel
     let fileTransferClient: FileTransferClient
@@ -57,7 +56,6 @@ private struct FileExplorerBody: View {
     
     @State private var path = FileTransferPathUtils.rootDirectory
 
-    
     var body: some View {
         let mainColor = Color.white.opacity(0.7)
         
@@ -126,24 +124,20 @@ private struct FileExplorerBody: View {
                 .foregroundColor(.white)
             }
             
-            
             // FileSystem
-            if let selectedClient = fileTransferClient {
+            ZStack {
+                FileSystemView(model: model, fileTransferClient: fileTransferClient, path: $path, isLoading: isLoading)
                 
-                ZStack {
-                    FileSystemView(model: model, fileTransferClient: selectedClient, path: $path, isLoading: isLoading)
-                    
-                    // Bottom status bar
-                    FileCommandsStatusBarView(model: model, backgroundColor: mainColor)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
-                }
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(mainColor)
-                )
-                .clipped()
-                .cornerRadius(8)
+                // Bottom status bar
+                FileCommandsStatusBarView(model: model, backgroundColor: mainColor)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
             }
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(mainColor)
+            )
+            .clipped()
+            .cornerRadius(8)
             
             Spacer()
         }
@@ -209,7 +203,6 @@ private struct FileExplorerBody: View {
                 .disabled(isLoading)
                 .sheet(isPresented: $showUploadFileDialog) { DocumentPicker(onUploadFile: onUploadFile)
                 }
-                
             }
         }
     }
@@ -218,18 +211,13 @@ private struct FileExplorerBody: View {
 struct FileExplorerView_Previews: PreviewProvider {
     static var previews: some View {
         TabView {
-            /*
-             let connectionManager = ConnectionManager(
-             wifiPeripheralScanner: BonjourScannerFake(),
-             onWifiPeripheralGetPasswordForHostName: nil
-             )
-             
-             FileExplorerView()
-             .tabItem {
-             Label("Explorer", systemImage: "folder")
-             }
-             .environmentObject(connectionManager)
-             */
+            let connectionManager = ConnectionManager(
+                bleManager: BleManagerFake(),
+                blePeripheralScanner: BlePeripheralScannerFake(),
+                wifiPeripheralScanner: BonjourScannerFake(),
+                onBlePeripheralBonded: nil,
+                onWifiPeripheralGetPasswordForHostName: nil
+            )
             
             let fileTransferClient = FileTransferClient(fileTransferPeripheral: WifiFileTransferPeripheral(wifiPeripheral: WifiPeripheral(name: "test", address: "127.0.0.1", port: 80), onGetPasswordForHostName: nil))
             
@@ -243,6 +231,7 @@ struct FileExplorerView_Previews: PreviewProvider {
                     .navigationBarTitle("File Explorer", displayMode: .inline)
             }
             .navigationViewStyle(StackNavigationViewStyle())
+            .environmentObject(connectionManager)
         }
     }
 }

--- a/Glider/Views/FileSystemView.swift
+++ b/Glider/Views/FileSystemView.swift
@@ -81,9 +81,23 @@ struct FileSystemView: View {
                 .padding(.bottom, 20)       // Add some margin because the status bar
             }
                         
-            VStack {
+            VStack(alignment: .center) {
                 // Empty view
-                Text("No files found")
+                VStack {
+                            Text("No Folders Found")
+                                .font(.headline)
+                                .foregroundColor(.primary)
+                                .padding()
+
+                    Text("Make sure you're using the latest CircuitPython version.")
+                        .multilineTextAlignment(.center)
+                                .font(.subheadline)
+                                .foregroundColor(.primary)
+                                .padding([.leading, .trailing, .bottom])
+                        }
+                        .background(Color("button_primary_accent"))
+                        .cornerRadius(10)
+                        .padding()
                     .foregroundColor(.white)
                     .if(showOnlyDirectories || model.isTransmitting || model.entries.count > 0) {
                         $0.hidden()


### PR DESCRIPTION
This PR updates the Transfer File web API version. The update involves modifications to the JSON structure with the latest version of CircuitPython. Changes include:

- Nesting file listings under a `files` object
- Adding folder information to the JSON response
- Incrementing the API version to 4 